### PR TITLE
fix CommentSidebar using React Portal

### DIFF
--- a/botani_grow/public/index.html
+++ b/botani_grow/public/index.html
@@ -36,6 +36,7 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="modal-root"></div>
+    <div id="comment-sidebar-root"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/botani_grow/src/views/organisms/CommentSidebar.scss
+++ b/botani_grow/src/views/organisms/CommentSidebar.scss
@@ -4,7 +4,7 @@
 
 .commentSidebarContainer {
   position: fixed;
-  top: 56px;
+  top: 0;
   right: 0;
   width: 450px;
   height: 100%;

--- a/botani_grow/src/views/organisms/CommentSidebar.tsx
+++ b/botani_grow/src/views/organisms/CommentSidebar.tsx
@@ -1,3 +1,4 @@
+import ReactDOM from 'react-dom';
 import React, { useState, useEffect } from 'react';
 import './CommentSidebar.scss';
 import { PlantInfo } from '../../types/plantInfo';
@@ -87,7 +88,7 @@ export const CommentSidebar: React.FC<CommentSidebarProps> = ({
     fetchComments();
   }, [plant.id]);
 
-  return (
+  return ReactDOM.createPortal(
     <div className={`commentSidebarContainer ${isSidebarOpen ? 'open' : ''}`}>
       <div className="comment-sidebar">
         <button className="close-btn" onClick={toggleCommentSidebar}>
@@ -134,6 +135,7 @@ export const CommentSidebar: React.FC<CommentSidebarProps> = ({
           ))}
         </div>
       </div>
-    </div>
+    </div>,
+    document.getElementById('comment-sidebar-root')!
   );
 };


### PR DESCRIPTION
React portalを使い、CommentSidebarコンポーネントを別のDOMに描画させた。
それによって親コンポーネントからCommentSidebarを独立させることができ、ComentSidebarのz-indexが画面に反映されるようになった。