### PR TITLE
update Register New Plant form UX

### DIFF
--- a/botani_grow/src/App.tsx
+++ b/botani_grow/src/App.tsx
@@ -124,7 +124,7 @@ function App() {
           {/* <Route path="/History" element={<History />} /> */}
           <Route path="/Reset" element={<Reset />} />
           <Route path="/Reset-Success" element={<ResetSuccess />} />
-          {/* <Route path="/AddNewPlant" element={<NewPlantForm />} /> */}
+          <Route path="/AddNewPlant" element={<NewPlantForm />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/botani_grow/src/pages/newPlantForm.tsx
+++ b/botani_grow/src/pages/newPlantForm.tsx
@@ -17,14 +17,12 @@ import { useNavigate } from 'react-router';
 import { FaTags } from 'react-icons/fa';
 import { PlantInfo } from '../types/plantInfo';
 import { TagsInput } from '../views/molecules/TagsInput';
-import { useModal } from '../hooks/useModal';
 
 type PlantProps = {
   plantsData?: PlantInfo[];
-  handleClose: () => void;
 };
 
-export const NewPlantForm: React.FC<PlantProps> = ({ handleClose }) => {
+export const NewPlantForm: React.FC<PlantProps> = () => {
   const [name, setName] = useState('');
   const [leafCount, setLeafCount] = useState(0);
   const wateringCycle = 14;
@@ -132,6 +130,11 @@ export const NewPlantForm: React.FC<PlantProps> = ({ handleClose }) => {
     } catch (e) {
       console.error('Error adding document: ', e);
     }
+  };
+
+  const handleCancel = () => {
+    // ユーザーを前のページに戻す
+    navigate(-1);
   };
 
   return (
@@ -262,17 +265,10 @@ export const NewPlantForm: React.FC<PlantProps> = ({ handleClose }) => {
                 <TagsInput tags={tags} setTags={setTags} />
               </div>
               <div className="btn-container flex  mt-1">
-                <button className="cancel-btn btn" onClick={handleClose}>
+                <button className="cancel-btn btn" onClick={handleCancel}>
                   <span>Cancel</span>
                 </button>
-                <button
-                  type="submit"
-                  className="add-plant-btn btn flex"
-                  onClick={() => {
-                    handleClose();
-                    navigate('/Plants');
-                  }}
-                >
+                <button type="submit" className="add-plant-btn btn flex">
                   <span>Submit</span>
                 </button>
               </div>

--- a/botani_grow/src/views/molecules/New.tsx
+++ b/botani_grow/src/views/molecules/New.tsx
@@ -1,40 +1,24 @@
 import './New.scss';
 
+import { Link } from 'react-router-dom';
 import { LiaSeedlingSolid } from 'react-icons/lia';
-import { NewPlantForm } from '../../pages/newPlantForm';
-import { useModal } from '../../hooks/useModal';
 
 export const New = () => {
-  const { Modal, openModal, closeModal, show } = useModal();
-
-  // NewPlantFormを開く処理
-  const handleOpen = () => {
-    openModal();
-  };
-
-  // NewPlantFormを閉じる処理
-  const handleClose = () => {
-    closeModal();
-  };
-
   return (
     <>
       <span className="relative group">
-        <button
+        <Link
+          to="/AddNewPlant"
           className="newPlant-Link  text-slate-700  text-base "
-          onClick={handleOpen}
         >
           <div className="newPlant-icon">
             <LiaSeedlingSolid />
           </div>
-        </button>
+        </Link>
         <span className="whitespace-nowrap rounded-lg bg-slate-700 px-2 py-1 text-sm text-white absolute top-12 -left-7 opacity-0 group-hover:opacity-100 transition pointer-events-none">
           Add new plant
         </span>
       </span>
-      <Modal show={show}>
-        <NewPlantForm handleClose={handleClose} />
-      </Modal>
     </>
   );
 };


### PR DESCRIPTION
新規登録フォーム(Register New Plant form)のモーダル化をやめた。
理由: データを入力しsubmiしてもローカルにデータが追加されない

またCancelボタンにnavigate(-1)の機能をつけて、クリックすると前いたページに戻れるようにした。