### PR TITLE
Editで変更した画像がしばらくすると勝手に消える問題の解決と、WateringModalのui変更

### DIFF
--- a/botani_grow/package-lock.json
+++ b/botani_grow/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.11.0",
+        "react-icons": "^4.12.0",
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "sass": "^1.67.0",
@@ -14120,9 +14120,9 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "node_modules/react-icons": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
-      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "peerDependencies": {
         "react": "*"
       }

--- a/botani_grow/package.json
+++ b/botani_grow/package.json
@@ -29,7 +29,7 @@
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.11.0",
+    "react-icons": "^4.12.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "sass": "^1.67.0",

--- a/botani_grow/src/pages/Details.tsx
+++ b/botani_grow/src/pages/Details.tsx
@@ -230,7 +230,7 @@ export const Details: React.FC<InfoProps> = ({
           </div>
 
           {/* メイン画面 */}
-          <div className="plant-detail-main flex-grow h-screen overflow-y-auto z-0">
+          <div className="plant-detail-main flex-grow h-screen z-0">
             {/* 植物ステータス　*/}
             <div className="flex justify-center gap-12 border-b pt-12 pb-8">
               {/* 水やりデータ + コンディション + メモ　*/}

--- a/botani_grow/src/views/organisms/Modal/Watering/FirstStep/WateringRate.tsx
+++ b/botani_grow/src/views/organisms/Modal/Watering/FirstStep/WateringRate.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-// import {FaStar} from "react-icons/fa"
 import { IoMdWater } from 'react-icons/io';
 
 import './WateringRate.scss';

--- a/botani_grow/src/views/organisms/Modal/Watering/SecondStep/SecondStepContent.scss
+++ b/botani_grow/src/views/organisms/Modal/Watering/SecondStep/SecondStepContent.scss
@@ -1,26 +1,48 @@
 .container {
   width: 280px;
   margin: auto;
-  //   background-color: #eee;
   border-radius: 10px;
 
   .wrapper {
-    margin: 3rem 0;
+    margin: 3rem 0 1rem 0;
 
     .emoji {
-      font-size: 1.7rem;
       display: flex;
       justify-content: center;
-      gap: 10px;
+      gap: 7px;
 
       button {
-        cursor: pointer;
-        transition: transform 0.2s ease-in;
+        font-size: 1.9rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 8px 18px 8px 18px;
+        border-radius: 10px;
+        transition: ease 0.3s;
+        opacity: 0.83;
+        color: rgb(185, 173, 173);
+
+        span {
+          font-size: 0.75rem;
+          margin-top: 10px;
+          color: var(--blackColor);
+          transition: ease 0.3s;
+        }
+
+        &:hover {
+          color: var(--blackColor);
+          background-color: rgb(229 231 235 / 0.5);
+          opacity: 1;
+        }
       }
-      button:hover {
-        transform: scale(1.6);
+
+      .button--active {
+        color: var(--blackColor);
+        background-color: rgb(229 231 235 / 0.5);
+        opacity: 1;
       }
     }
+
     .text {
       margin-top: 0.5rem;
       margin-bottom: 0.5rem;
@@ -31,7 +53,6 @@
   textarea {
     width: 100%;
     display: block;
-    // background-color: #9b9595;
     color: white;
     border: solid 1px var(--bgColor);
     border-radius: 10px;
@@ -44,10 +65,9 @@
   }
 
   .textarea--active {
-    padding: 1rem;
+    padding: 0.5rem 0.7rem;
     opacity: 1;
-    height: 6rem;
+    height: 5rem;
     color: black;
-    padding: 8px;
   }
 }

--- a/botani_grow/src/views/organisms/Modal/Watering/SecondStep/SecondStepContent.tsx
+++ b/botani_grow/src/views/organisms/Modal/Watering/SecondStep/SecondStepContent.tsx
@@ -1,58 +1,59 @@
 import React, { useState } from 'react';
 
 import './SecondStepContent.scss';
+import { BsEmojiTear } from 'react-icons/bs';
+import { BsEmojiNeutral } from 'react-icons/bs';
+import { BsEmojiKiss } from 'react-icons/bs';
 
 export const SecondStepContent = () => {
   const [isActive, setIsActive] = useState<boolean>(false);
   const [selectedEmoji, setSelectedEmoji] = useState<string>('');
 
   const handleEmojiClick = (emoji: string) => {
+    if (selectedEmoji !== emoji) {
+      setSelectedEmoji(emoji);
+    }
+
     setIsActive(true);
-    setSelectedEmoji(emoji);
+    console.log(selectedEmoji);
   };
 
-  const handleMouseLeave = () => {
-    setIsActive(false);
-  };
-
-  // 絵文字に応じて表示するテキストを定義するオブジェクト
-  const emojiMessages = {
-    // soBad: '枯れる寸前',
-    bad: 'わるい',
-    normal: 'ふつう',
-    good: '良い',
-    // soGood: 'とても良い',
+  const getButtonClass = (emoji: string) => {
+    return `button ${selectedEmoji === emoji ? 'button--active' : ''}`;
   };
 
   return (
     <>
-      {/* <div>step 2</div> */}
-      <div className="container" onMouseLeave={handleMouseLeave}>
+      <div className="container">
         <div className="wrapper">
-          <p className="text">植物の状態</p>
+          <p className="text">今の状態は?</p>
           <div className="emoji">
-            {/* <button onClick={() => handleEmojiClick('🤕')} className="so bad">
-              🤕
-            </button> */}
-            <button onClick={() => handleEmojiClick('😖')} className="bad">
-              😖
+            <button
+              onClick={() => handleEmojiClick('bad')}
+              className={getButtonClass('bad')}
+            >
+              <BsEmojiTear /> <span>悪い ...</span>
             </button>
-            <button onClick={() => handleEmojiClick('😐')} className="normal">
-              😐
+            <button
+              onClick={() => handleEmojiClick('normal')}
+              className={getButtonClass('normal')}
+            >
+              <BsEmojiNeutral />
+              <span>ふつう</span>
             </button>
-            <button onClick={() => handleEmojiClick('😊')} className="good">
-              😊
+            <button
+              onClick={() => handleEmojiClick('good')}
+              className={getButtonClass('good')}
+            >
+              <BsEmojiKiss /> <span>良い !</span>
             </button>
-            {/* <button onClick={() => handleEmojiClick('😍')} className="so good">
-              😍
-            </button> */}
           </div>
         </div>
 
         <textarea
           className={`textarea ${isActive ? 'textarea--active' : ''}`}
           maxLength={100}
-          placeholder="観察メモ"
+          placeholder="コメント"
         ></textarea>
       </div>
     </>

--- a/botani_grow/src/views/organisms/Modal/Watering/ThirdStep/ThirdStepContent.scss
+++ b/botani_grow/src/views/organisms/Modal/Watering/ThirdStep/ThirdStepContent.scss
@@ -1,0 +1,3 @@
+.nextWateringDate {
+  padding-top: 50px;
+}

--- a/botani_grow/src/views/organisms/Modal/Watering/ThirdStep/ThirdStepContent.tsx
+++ b/botani_grow/src/views/organisms/Modal/Watering/ThirdStep/ThirdStepContent.tsx
@@ -1,5 +1,23 @@
 import React from 'react';
 
-export const ThirdStepContent = () => {
-  return <div>Done</div>;
+import { PlantInfo } from '../../../../../types/plantInfo';
+
+type WateringPlantProps = {
+  plant: PlantInfo;
+};
+
+export const ThirdStepContent: React.FC<WateringPlantProps> = ({ plant }) => {
+  const { iconUrl, name } = plant;
+  return (
+    <>
+      {iconUrl && (
+        <img src={iconUrl} alt={name} className="wateringPlantIcon mx-auto" />
+      )}
+      <div className="mx-auto text-gray-800 pt-12 ">
+        {name}の 次回の水やり日は
+        <br />
+      </div>
+      <div className="mt-3 text-gray-800 text-lg">4月21日です</div>
+    </>
+  );
 };

--- a/botani_grow/src/views/organisms/Modal/Watering/WateringModal.tsx
+++ b/botani_grow/src/views/organisms/Modal/Watering/WateringModal.tsx
@@ -40,7 +40,7 @@ export const WateringModal: React.FC<WateringModalProps> = ({
       case 2:
         return <SecondStepContent />;
       case 3:
-        return <ThirdStepContent />;
+        return <ThirdStepContent plant={plant} />;
       default:
         return null;
     }
@@ -92,7 +92,7 @@ export const WateringModal: React.FC<WateringModalProps> = ({
                   <span>
                     {step == 1 && 'Next'}
                     {step == 2 && 'Submit'}
-                    {step > 2 && 'Okay'}
+                    {step > 2 && 'Done'}
                   </span>
                   {step == 1 && <TbChevronRight />}
                 </div>

--- a/botani_grow/yarn.lock
+++ b/botani_grow/yarn.lock
@@ -8613,10 +8613,10 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-icons@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz"
-  integrity sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==
+react-icons@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz"
+  integrity sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==
 
 react-is@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
起こった問題と考察

Editで画像を更新後、画面をリロードすると植物プロフィール画像が更新されている
↓
しばらくすると、植物プロフィール画像が無くなって、白の背景のみになってしまう。
↓
Firebaseのストレージを確認すると、画像がちゃんと在る
↓
ではなぜ、画像が消えてしまうのか
↓
Firebaseのデータベースを見ると、どうやら、ローカルに一時保存された画像URLが植物のプロフィール画像に用いられていていることに気が付く
↓
ローカルに保存された画像URLを用いたところで、キャッシュがクリアされると同時に画像も消えてしまう
↓
そこで、ローカルではなく、
Firebaseのストレージに保存された画像URLを植物プロフィール画像URLとして用いるようにする
↓
これならば、時間がたってもFirebaseのストレージに画像URLがある限り画像が消えることはなくなる！
